### PR TITLE
Fix magic get method for microformats type

### DIFF
--- a/src/p3k/Micropub/Request.php
+++ b/src/p3k/Micropub/Request.php
@@ -182,6 +182,8 @@ class Request {
 
   public function __get($k) {
     switch($k) {
+      case 'type':
+        return reset($this->_type);
       case 'action':
         return $this->_action;
       case 'commands':

--- a/src/p3k/Micropub/Request.php
+++ b/src/p3k/Micropub/Request.php
@@ -61,8 +61,13 @@ class Request {
 
     if(isset($input['type'])) {
 
-      if(!is_array($input['type']))
+      if(!is_array($input['type'])) {
         return new Error('invalid_input', 'type', 'Property type must be an array of Microformat vocabularies');
+      }
+
+      if (count($input['type']) === 0) {
+        return new Error('invalid_input', 'type', 'Property type must contain at least one Microformat vocabulary');
+      }
 
       $request->_action = 'create';
       $request->_type = $input['type'];
@@ -116,7 +121,7 @@ class Request {
       return new Error('invalid_input', null, 'No Micropub request data was found in the input');
     }
 
-    return $request;    
+    return $request;
   }
 
   public static function createFromPostArray($POST) {
@@ -183,7 +188,7 @@ class Request {
   public function __get($k) {
     switch($k) {
       case 'type':
-        return reset($this->_type);
+        return $this->_type[0];
       case 'action':
         return $this->_action;
       case 'commands':

--- a/tests/JSONInputTest.php
+++ b/tests/JSONInputTest.php
@@ -107,6 +107,16 @@ class JSONInputTest extends PHPUnit_Framework_TestCase {
     $this->assertEquals('type', $request->error_property);
   }
 
+  public function testFailOnEmptyTypeArray() {
+    $input = [
+      'type' => [],
+      'properties' => [],
+    ];
+    $request = \p3k\Micropub\Request::createFromJSONObject($input);
+    $this->assertInstanceOf(\p3k\Micropub\Error::class, $request);
+    $this->assertEquals('type', $request->error_property);
+  }
+
   public function testFailOnMissingProperties() {
     $input = [
       'type' => ['h-entry'],

--- a/tests/MagicMethodsTest.php
+++ b/tests/MagicMethodsTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use p3k\Micropub\Request;
+
+class MagicMethodsTest extends PHPUnit_Framework_TestCase {
+
+  public function testGetType() {
+    $request = Request::create([
+      'h' => 'entry',
+      'content' => 'Hello World'
+    ]);
+    $this->assertEquals('h-entry', $request->type);
+  }
+
+  public function testGetActionCreate() {
+    $request = Request::create([
+      'h' => 'entry',
+      'content' => 'Hello World'
+    ]);
+    $this->assertEquals('create', $request->action);
+  }
+
+  public function testGetActionUpdate() {
+    $request = Request::createFromJSONObject([
+      'action' => 'update',
+      'url' => 'https://example.com/post',
+      'replace' => [
+        'content' => ['Hello World']
+      ],
+    ]);
+    $this->assertEquals('update', $request->action);
+  }
+
+  public function testGetActionDelete() {
+    $request = Request::createFromPostArray([
+      'action' => 'delete',
+      'url' => 'https://example.com/post',
+    ]);
+    $this->assertEquals('delete', $request->action);
+  }
+
+}
+


### PR DESCRIPTION
The `$request->type` magic get method in the code example wasn't working. Added a test for that as well as a few tests for the `action` attribute in `MagicMethodsTest.php`